### PR TITLE
Added const keyword to PROGMEM variable to address a compile error.

### DIFF
--- a/samples/dashboard_4884/font_6x8.h
+++ b/samples/dashboard_4884/font_6x8.h
@@ -3,7 +3,7 @@
 // index = ASCII - 32
 #include <avr/pgmspace.h>
 
-unsigned char  font6_8[][6] PROGMEM =
+const unsigned char  font6_8[][6] PROGMEM =
 {
     { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },   // sp
     { 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00 },   // !

--- a/samples/dashboard_4884/font_big.h
+++ b/samples/dashboard_4884/font_big.h
@@ -6,7 +6,7 @@
 //******* VERY LARGE FONTS ********** 
 //used here for displaying temperature
 
-unsigned char   big_number[13][3][16] PROGMEM = {
+const unsigned char   big_number[13][3][16] PROGMEM = {
 
 0,128,192,224,224,96,224,224,  //'0'
 192,128,0,0,0,0,0,0


### PR DESCRIPTION
In file included from /Users/petersni/Desktop/Arduino.app/Contents/Resources/Java/hardware/arduino/avr/cores/arduino/Arduino.h:28:0,
                 from LCD4884.h:21,
                 from LCD4884.cpp:17:
font_6x8.h:6:29: error: variable 'font6_8' must be const in order to be put into read-only section by means of '**attribute**((progmem))'
 unsigned char  font6_8[][6] PROGMEM =
                             ^
font_big.h:9:39: error: variable 'big_number' must be const in order to be put into read-only section by means of '**attribute**((progmem))'
 unsigned char   big_number[13][3][16] PROGMEM = {
                                       ^
Error compiling.
